### PR TITLE
Fix jito_mempool_listener imports

### DIFF
--- a/jito_mempool_listener.py
+++ b/jito_mempool_listener.py
@@ -12,18 +12,20 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import base64
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Dict, Optional
+from typing import Optional
 
 import grpc
 from rich.console import Console
 from rich.table import Table
-from solana.publickey import PublicKey
-from solana.rpc.async_api import AsyncClient
-from solana.transaction import VersionedTransaction
+
+# --- Modern Solana SDK imports ---
+from solders.pubkey import Pubkey as PublicKey
 from solders.keypair import Keypair
+from solders.transaction import VersionedTransaction
+from solana.rpc.async_api import AsyncClient
+
 import os
 
 # Jito protobuf stubs (generated from jito_protos)


### PR DESCRIPTION
## Summary
- use solders `Pubkey` and `VersionedTransaction` instead of deprecated solana types
- tidy imports and keep `from __future__` at top to avoid syntax errors

## Testing
- `python -m py_compile jito_mempool_listener.py`
- `python jito_mempool_listener.py --help` *(fails: ModuleNotFoundError: No module named 'grpc')*
- `pip install grpcio` *(fails: Could not find a version that satisfies the requirement grpcio)*

------
https://chatgpt.com/codex/tasks/task_e_689398a013ac832b90cd9d3b74771c65