### PR TITLE
fix: correct SolanaClient endpoint parameter

### DIFF
--- a/jito_mempool_listener.py
+++ b/jito_mempool_listener.py
@@ -80,7 +80,7 @@ async def fetch_sol_price() -> float:
 
     client = PythClient(
         first_mapping_account_key=SOL_USD_PRICE_ACCOUNT,
-        solana_client=SolanaClient(RPC_URL),
+        solana_client=SolanaClient(endpoint=RPC_URL),
     )
     await client.refresh_all_prices()
     price = client.get_price(SOL_USD_PRICE_ACCOUNT).price


### PR DESCRIPTION
## Summary
- fix SOL price fetching by passing SolanaClient endpoint as keyword

## Testing
- `python -m py_compile jito_mempool_listener.py`
- `cargo test` *(fails: failed to read `/workspace/Jito/tmev-cli/Cargo.toml`)*

------
https://chatgpt.com/codex/tasks/task_e_6893a5598b04832b8b51c732c377ae7d