### PR TITLE
Improve mempool listener resilience

### DIFF
--- a/jito_mempool_listener.py
+++ b/jito_mempool_listener.py
@@ -16,6 +16,8 @@ import asyncio
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Optional
+import random
+import time
 
 import logging
 from rich.console import Console
@@ -97,27 +99,33 @@ async def process_tx(
     sig = str(tx.signatures[0])
 
     sim = await rpc.simulate_transaction(tx, sig_verify=False)
-    if sim.value is None:
+    val = getattr(sim, "value", None)
+    if not val:
         return None
 
-    tb = [b for b in sim.value.post_token_balances if b.mint == str(target_mint)]
-    if not tb:
+    tb_post = [b for b in (val.post_token_balances or []) if b.mint == str(target_mint)]
+    if not tb_post:
         return None
 
-    token_post = tb[0]
+    token_post = tb_post[0]
     token_pre = next(
-        (b for b in sim.value.pre_token_balances if b.owner == token_post.owner),
+        (b for b in (val.pre_token_balances or []) if b.owner == token_post.owner),
         None,
     )
-    decimals = token_post.ui_token_amount.decimals
-    post_amt = int(token_post.ui_token_amount.amount)
-    pre_amt = int(token_pre.ui_token_amount.amount) if token_pre else 0
-    token_delta = (post_amt - pre_amt) / 10 ** decimals
 
-    owner_index = keys.index(PublicKey.from_string(token_post.owner))
-    sol_pre = sim.value.pre_balances[owner_index]
-    sol_post = sim.value.post_balances[owner_index]
-    sol_delta = (sol_post - sol_pre) / 10 ** 9
+    decimals = token_post.ui_token_amount.decimals or 0
+    post_amt = int(token_post.ui_token_amount.amount or 0)
+    pre_amt = int((token_pre.ui_token_amount.amount if token_pre else 0) or 0)
+    token_delta = (post_amt - pre_amt) / (10 ** decimals if decimals else 1)
+
+    try:
+        owner_pk = PublicKey.from_string(token_post.owner)
+        owner_index = list(tx.message.account_keys).index(owner_pk)
+        sol_pre = (val.pre_balances or [0] * len(tx.message.account_keys))[owner_index]
+        sol_post = (val.post_balances or [0] * len(tx.message.account_keys))[owner_index]
+        sol_delta = (sol_post - sol_pre) / 1e9
+    except Exception:
+        sol_delta = 0.0
 
     if token_delta == 0 and sol_delta == 0:
         return None
@@ -150,39 +158,63 @@ async def stream_mempool(target_mint: PublicKey) -> None:
         kp = Keypair.from_bytes(open(KEYPAIR_PATH, "rb").read())
         print(f"Using existing keypair at {KEYPAIR_PATH}")
     rpc = AsyncClient(RPC_URL)
-    sol_price = await fetch_sol_price()
-    logger.debug("Fetched SOL price: %s", sol_price)
 
-    logger.debug("Connecting to block engine at %s", BLOCK_ENGINE_HOST)
-    client = await get_async_searcher_client(BLOCK_ENGINE_HOST, kp)
+    sol_price_holder = {"p": await fetch_sol_price()}
+    logger.debug("Fetched SOL price: %s", sol_price_holder["p"])
 
-    request = PendingTxSubscriptionRequest(accounts=[])
+    async def sol_price_refresher(interval: int = 15) -> None:
+        while True:
+            p = await fetch_sol_price()
+            if p > 0:
+                sol_price_holder["p"] = p
+            await asyncio.sleep(interval)
+
+    asyncio.create_task(sol_price_refresher(15))
 
     console = Console()
-    table = Table(
-        "Time", "Side", "SOL In/Out", "Token In/Out", "Price (SOL)", "Price (USD)", "Tx Hash"
-    )
+    rows = []
+    last_flush = time.time()
 
-    try:
-        async for notification in client.SubscribePendingTransactions(request):
-            for packet in notification.transactions:
-                tx = VersionedTransaction.from_bytes(packet.data)
-                row = await process_tx(tx, rpc, target_mint, sol_price)
-                if row:
-                    table.add_row(
-                        row.time,
-                        row.side,
-                        f"{row.sol:.6f}",
-                        f"{row.token:.4f}",
-                        f"{row.price_sol:.8f}",
-                        f"${row.price_usd:.5f}",
-                        row.sig,
+    while True:
+        try:
+            logger.debug("Connecting to block engine at %s", BLOCK_ENGINE_HOST)
+            client = await get_async_searcher_client(BLOCK_ENGINE_HOST, kp)
+            request = PendingTxSubscriptionRequest(accounts=[])
+            async for notification in client.SubscribePendingTransactions(request):
+                for packet in notification.transactions:
+                    tx = VersionedTransaction.from_bytes(packet.data)
+                    row = await process_tx(tx, rpc, target_mint, sol_price_holder["p"])
+                    if row:
+                        rows.append(row)
+
+                now = time.time()
+                if rows and (now - last_flush) >= 0.2:
+                    table = Table(
+                        "Time",
+                        "Side",
+                        "SOL In/Out",
+                        "Token In/Out",
+                        "Price (SOL)",
+                        "Price (USD)",
+                        "Tx Hash",
                     )
+                    for r in rows:
+                        table.add_row(
+                            r.time,
+                            r.side,
+                            f"{r.sol:.6f}",
+                            f"{r.token:.4f}",
+                            f"{r.price_sol:.8f}",
+                            f"${r.price_usd:.5f}",
+                            r.sig,
+                        )
                     console.print(table)
-                    table.rows.clear()
-    except Exception as e:  # pragma: no cover - debug aid
-        logger.exception(f"Mempool stream terminated: {e}")
-        raise
+                    rows.clear()
+                    last_flush = now
+        except Exception as e:
+            logger.warning("Stream error: %s; retrying…", e)
+            await asyncio.sleep(min(60, 1 + random.random() * 2))
+            continue
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- add defensive transaction simulation to avoid missing keys or empty balances
- auto-refresh SOL price while streaming and handle transient errors
- reconnect to block engine with jittered backoff and batch console output

## Testing
- `python -m py_compile jito_mempool_listener.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896a0e85f24832b99dd5f96741acf4a